### PR TITLE
Fetch and process glucose history data

### DIFF
--- a/Common/src/main/java/tk/glucodata/WatchdripHistory.java
+++ b/Common/src/main/java/tk/glucodata/WatchdripHistory.java
@@ -1,0 +1,291 @@
+/*      This file is part of Juggluco, an Android app to receive and display         */
+/*      glucose values from Freestyle Libre 2 and 3 sensors.                         */
+/*                                                                                   */
+/*      Copyright (C) 2021 Jaap Korthals Altes <jaapkorthalsaltes@gmail.com>         */
+/*                                                                                   */
+/*      Juggluco is free software: you can redistribute it and/or modify             */
+/*      it under the terms of the GNU General Public License as published            */
+/*      by the GNU General Public License Foundation, either version 3 of the License, or         */
+/*      (at your option) any later version.                                          */
+/*                                                                                   */
+/*      Juggluco is distributed in the hope that it will be useful, but              */
+/*      WITHOUT ANY WARRANTY; without even the implied warranty of                   */
+/*      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                         */
+/*      See the GNU General Public License for more details.                         */
+/*                                                                                   */
+/*      You should have received a copy of the GNU General Public License            */
+/*      along with Juggluco. If not, see <https://www.gnu.org/licenses/>.            */
+
+package tk.glucodata;
+
+import static tk.glucodata.Log.doLog;
+
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+
+/**
+ * Utility class for accessing watchdrip glucose history functionality.
+ * This class provides a clean interface to the watchdrip history system
+ * and integrates with the existing glucose data flow.
+ */
+public class WatchdripHistory {
+    private static final String LOG_ID = "WatchdripHistory";
+    
+    /**
+     * Get all glucose history for a specific sensor
+     * @param serial Sensor serial number
+     * @return List of glucose readings, empty list if none available
+     */
+    public static List<watchdrip.GlucoseReading> getHistory(String serial) {
+        try {
+            return watchdrip.getGlucoseHistory(serial);
+        } catch (Exception e) {
+            if(doLog) Log.e(LOG_ID, "Error getting history for " + serial + ": " + e.getMessage());
+            return new ArrayList<>();
+        }
+    }
+    
+    /**
+     * Get glucose history for a specific sensor within a time range
+     * @param serial Sensor serial number
+     * @param startMillis Start time in milliseconds
+     * @param endMillis End time in milliseconds
+     * @return List of glucose readings within the time range
+     */
+    public static List<watchdrip.GlucoseReading> getHistory(String serial, long startMillis, long endMillis) {
+        try {
+            return watchdrip.getGlucoseHistory(serial, startMillis, endMillis);
+        } catch (Exception e) {
+            if(doLog) Log.e(LOG_ID, "Error getting history for " + serial + " in range: " + e.getMessage());
+            return new ArrayList<>();
+        }
+    }
+    
+    /**
+     * Get the latest glucose reading for a sensor
+     * @param serial Sensor serial number
+     * @return Latest glucose reading or null if none available
+     */
+    public static watchdrip.GlucoseReading getLatest(String serial) {
+        try {
+            return watchdrip.getLatestGlucose(serial);
+        } catch (Exception e) {
+            if(doLog) Log.e(LOG_ID, "Error getting latest glucose for " + serial + ": " + e.getMessage());
+            return null;
+        }
+    }
+    
+    /**
+     * Get glucose history for the last N hours
+     * @param serial Sensor serial number
+     * @param hours Number of hours to look back
+     * @return List of glucose readings from the last N hours
+     */
+    public static List<watchdrip.GlucoseReading> getRecentHistory(String serial, int hours) {
+        try {
+            long endMillis = System.currentTimeMillis();
+            long startMillis = endMillis - (hours * 60 * 60 * 1000L);
+            return watchdrip.getGlucoseHistory(serial, startMillis, endMillis);
+        } catch (Exception e) {
+            if(doLog) Log.e(LOG_ID, "Error getting recent history for " + serial + ": " + e.getMessage());
+            return new ArrayList<>();
+        }
+    }
+    
+    /**
+     * Get glucose history for the last 24 hours
+     * @param serial Sensor serial number
+     * @return List of glucose readings from the last 24 hours
+     */
+    public static List<watchdrip.GlucoseReading> getDailyHistory(String serial) {
+        return getRecentHistory(serial, 24);
+    }
+    
+    /**
+     * Get glucose history for the last 7 days
+     * @param serial Sensor serial number
+     * @return List of glucose readings from the last 7 days
+     */
+    public static List<watchdrip.GlucoseReading> getWeeklyHistory(String serial) {
+        return getRecentHistory(serial, 24 * 7);
+    }
+    
+    /**
+     * Get sorted glucose history (oldest first)
+     * @param serial Sensor serial number
+     * @return Sorted list of glucose readings
+     */
+    public static List<watchdrip.GlucoseReading> getSortedHistory(String serial) {
+        List<watchdrip.GlucoseReading> history = getHistory(serial);
+        Collections.sort(history, Comparator.comparingLong(r -> r.timeMillis));
+        return history;
+    }
+    
+    /**
+     * Get sorted glucose history within a time range (oldest first)
+     * @param serial Sensor serial number
+     * @param startMillis Start time in milliseconds
+     * @param endMillis End time in milliseconds
+     * @return Sorted list of glucose readings within the time range
+     */
+    public static List<watchdrip.GlucoseReading> getSortedHistory(String serial, long startMillis, long endMillis) {
+        List<watchdrip.GlucoseReading> history = getHistory(serial, startMillis, endMillis);
+        Collections.sort(history, Comparator.comparingLong(r -> r.timeMillis));
+        return history;
+    }
+    
+    /**
+     * Get glucose statistics for a sensor
+     * @param serial Sensor serial number
+     * @return Glucose statistics object
+     */
+    public static GlucoseStats getStats(String serial) {
+        List<watchdrip.GlucoseReading> history = getHistory(serial);
+        if (history.isEmpty()) {
+            return new GlucoseStats();
+        }
+        
+        return new GlucoseStats(history);
+    }
+    
+    /**
+     * Get glucose statistics for a sensor within a time range
+     * @param serial Sensor serial number
+     * @param startMillis Start time in milliseconds
+     * @param endMillis End time in milliseconds
+     * @return Glucose statistics object
+     */
+    public static GlucoseStats getStats(String serial, long startMillis, long endMillis) {
+        List<watchdrip.GlucoseReading> history = getHistory(serial, startMillis, endMillis);
+        if (history.isEmpty()) {
+            return new GlucoseStats();
+        }
+        
+        return new GlucoseStats(history);
+    }
+    
+    /**
+     * Check if a sensor has any glucose history
+     * @param serial Sensor serial number
+     * @return true if history exists, false otherwise
+     */
+    public static boolean hasHistory(String serial) {
+        try {
+            List<watchdrip.GlucoseReading> history = watchdrip.getGlucoseHistory(serial);
+            return history != null && !history.isEmpty();
+        } catch (Exception e) {
+            return false;
+        }
+    }
+    
+    /**
+     * Get the number of glucose readings for a sensor
+     * @param serial Sensor serial number
+     * @return Number of glucose readings
+     */
+    public static int getHistoryCount(String serial) {
+        try {
+            List<watchdrip.GlucoseReading> history = watchdrip.getGlucoseHistory(serial);
+            return history != null ? history.size() : 0;
+        } catch (Exception e) {
+            return 0;
+        }
+    }
+    
+    /**
+     * Glucose statistics class
+     */
+    public static class GlucoseStats {
+        public final int count;
+        public final float minValue;
+        public final float maxValue;
+        public final float avgValue;
+        public final float minRate;
+        public final float maxRate;
+        public final float avgRate;
+        public final int lowAlarmCount;
+        public final int highAlarmCount;
+        public final int normalCount;
+        
+        public GlucoseStats() {
+            this.count = 0;
+            this.minValue = 0;
+            this.maxValue = 0;
+            this.avgValue = 0;
+            this.minRate = 0;
+            this.maxRate = 0;
+            this.avgRate = 0;
+            this.lowAlarmCount = 0;
+            this.highAlarmCount = 0;
+            this.normalCount = 0;
+        }
+        
+        public GlucoseStats(List<watchdrip.GlucoseReading> history) {
+            this.count = history.size();
+            
+            if (count == 0) {
+                this.minValue = 0;
+                this.maxValue = 0;
+                this.avgValue = 0;
+                this.minRate = 0;
+                this.maxRate = 0;
+                this.avgRate = 0;
+                this.lowAlarmCount = 0;
+                this.highAlarmCount = 0;
+                this.normalCount = 0;
+                return;
+            }
+            
+            float sumValue = 0;
+            float sumRate = 0;
+            float minVal = Float.MAX_VALUE;
+            float maxVal = Float.MIN_VALUE;
+            float minRateVal = Float.MAX_VALUE;
+            float maxRateVal = Float.MIN_VALUE;
+            int lowCount = 0;
+            int highCount = 0;
+            int normalCount = 0;
+            
+            for (watchdrip.GlucoseReading reading : history) {
+                // Value statistics
+                sumValue += reading.value;
+                if (reading.value < minVal) minVal = reading.value;
+                if (reading.value > maxVal) maxVal = reading.value;
+                
+                // Rate statistics
+                sumRate += reading.rate;
+                if (reading.rate < minRateVal) minRateVal = reading.rate;
+                if (reading.rate > maxRateVal) maxRateVal = reading.rate;
+                
+                // Alarm statistics
+                if ((reading.alarm & 4) == 4) {
+                    if ((reading.alarm & 1) == 1) {
+                        lowCount++;
+                    } else {
+                        highCount++;
+                    }
+                } else {
+                    normalCount++;
+                }
+            }
+            
+            this.minValue = minVal;
+            this.maxValue = maxVal;
+            this.avgValue = sumValue / count;
+            this.minRate = minRateVal;
+            this.maxRate = maxRateVal;
+            this.avgRate = sumRate / count;
+            this.lowAlarmCount = lowCount;
+            this.highAlarmCount = highCount;
+            this.normalCount = normalCount;
+        }
+        
+        @Override
+        public String toString() {
+            return String.format("GlucoseStats{count=%d, value[%.1f-%.1f avg=%.1f], rate[%.2f-%.2f avg=%.2f], alarms[low=%d, high=%d, normal=%d]}",
+                    count, minValue, maxValue, avgValue, minRate, maxRate, avgRate, lowAlarmCount, highAlarmCount, normalCount);
+        }
+    }
+}

--- a/Common/src/main/java/tk/glucodata/headless/HeadlessHistory.java
+++ b/Common/src/main/java/tk/glucodata/headless/HeadlessHistory.java
@@ -1,32 +1,155 @@
 package tk.glucodata.headless;
 
 import tk.glucodata.Natives;
+import tk.glucodata.watchdrip;
+import tk.glucodata.Applic;
+
+import java.util.List;
+import java.util.ArrayList;
 
 public final class HeadlessHistory {
     private final HistoryListener listener;
+    private final GlucoseListener glucoseListener;
 
     public HeadlessHistory(HistoryListener listener) {
         this.listener = listener;
+        this.glucoseListener = null;
+    }
+
+    public HeadlessHistory(GlucoseListener glucoseListener) {
+        this.listener = null;
+        this.glucoseListener = glucoseListener;
+    }
+
+    public HeadlessHistory(HistoryListener historyListener, GlucoseListener glucoseListener) {
+        this.listener = historyListener;
+        this.glucoseListener = glucoseListener;
     }
 
     // Uses Natives.getlastGlucose() which returns a flat long[] as
     // [timeSeconds0, packed0, timeSeconds1, packed1, ...].
-    // The packed value is Q32.32 fixed-point mmol/L in a 64-bit long.
-    // We transform it into pairs [timeMillis, mgdl] where mgdl is rounded.
+    // The packed value contains glucose data, rate, and alarm information.
+    // We transform it into onGlucose calls matching the watchdrip structure.
     public void emitFromNativeLast(String serial) {
+        if (glucoseListener == null) return;
+        long[] flat = Natives.getlastGlucose();
+        if (flat == null || flat.length < 2) return;
+        emitGlucoseReadings(serial, flat, null, null);
+    }
+
+    public void emitFromNativeRange(String serial, Long startMillis, Long endMillis) {
+        if (glucoseListener == null) return;
+        long[] flat = Natives.getlastGlucose();
+        if (flat == null || flat.length < 2) return;
+        emitGlucoseReadings(serial, flat, startMillis, endMillis);
+    }
+
+    // Legacy method for backward compatibility
+    public void emitFromNativeLastLegacy(String serial) {
         if (listener == null) return;
         long[] flat = Natives.getlastGlucose();
         if (flat == null || flat.length < 2) return;
         listener.onHistory(serial, toPairs(flat, null, null));
     }
 
-    public void emitFromNativeRange(String serial, Long startMillis, Long endMillis) {
+    public void emitFromNativeRangeLegacy(String serial, Long startMillis, Long endMillis) {
         if (listener == null) return;
         long[] flat = Natives.getlastGlucose();
         if (flat == null || flat.length < 2) return;
         listener.onHistory(serial, toPairs(flat, startMillis, endMillis));
     }
 
+    /**
+     * Emit glucose readings using onGlucose method based on watchdrip structure
+     */
+    private void emitGlucoseReadings(String serial, long[] flat, Long startMillis, Long endMillis) {
+        int totalPairs = flat.length / 2;
+        
+        for (int i = 0; i < totalPairs; i++) {
+            long tMillis = flat[2 * i] * 1000L; // native gives seconds, convert to milliseconds
+            
+            // Check time range filter
+            if (startMillis != null && tMillis < startMillis) continue;
+            if (endMillis != null && tMillis > endMillis) continue;
+            
+            long packed = flat[2 * i + 1];
+            
+            // Decode glucose data using watchdrip structure
+            int glumgdl = (int) (packed & 0xFFFFFFFFL);
+            if (glumgdl == 0) continue; // Skip invalid readings
+            
+            int alarm = (int) ((packed >> 48) & 0xFFL);
+            short ratein = (short) ((packed >> 32) & 0xFFFFL);
+            float rate = ratein / 1000.0f;
+            
+            // Convert to current units (same as watchdrip)
+            float value = Applic.unit == 1 ? glumgdl / Applic.mgdLmult : glumgdl;
+            
+            // Get sensor information (default values if not available)
+            long sensorStartMillis = System.currentTimeMillis() - (24 * 60 * 60 * 1000L); // Default to 24 hours ago
+            int sensorGen = 1; // Default sensor generation
+            
+            // Call onGlucose with decoded data
+            try {
+                glucoseListener.onGlucose(serial, glumgdl, value, rate, alarm, tMillis, sensorStartMillis, sensorGen);
+            } catch (Exception e) {
+                // Log error but continue processing other readings
+                System.err.println("Error calling onGlucose: " + e.getMessage());
+            }
+        }
+    }
+
+    /**
+     * Get glucose history from watchdrip if available
+     */
+    public void emitFromWatchdripHistory(String serial) {
+        if (glucoseListener == null) return;
+        
+        try {
+            List<watchdrip.GlucoseReading> history = watchdrip.getGlucoseHistory(serial);
+            for (watchdrip.GlucoseReading reading : history) {
+                glucoseListener.onGlucose(
+                    reading.serial,
+                    reading.mgdl,
+                    reading.value,
+                    reading.rate,
+                    reading.alarm,
+                    reading.timeMillis,
+                    reading.sensorStartMillis,
+                    reading.sensorGen
+                );
+            }
+        } catch (Exception e) {
+            System.err.println("Error getting watchdrip history: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Get glucose history from watchdrip within a time range
+     */
+    public void emitFromWatchdripHistory(String serial, Long startMillis, Long endMillis) {
+        if (glucoseListener == null) return;
+        
+        try {
+            List<watchdrip.GlucoseReading> history = watchdrip.getGlucoseHistory(serial, startMillis, endMillis);
+            for (watchdrip.GlucoseReading reading : history) {
+                glucoseListener.onGlucose(
+                    reading.serial,
+                    reading.mgdl,
+                    reading.value,
+                    reading.rate,
+                    reading.alarm,
+                    reading.timeMillis,
+                    reading.sensorStartMillis,
+                    reading.sensorGen
+                );
+            }
+        } catch (Exception e) {
+            System.err.println("Error getting watchdrip history: " + e.getMessage());
+        }
+    }
+
+    // Legacy method for backward compatibility - keep the old toPairs implementation
     private static long[][] toPairs(long[] flat, Long startMillis, Long endMillis) {
         int totalPairs = flat.length / 2;
         int count = 0;

--- a/Common/src/main/java/tk/glucodata/headless/HeadlessHistoryExample.java
+++ b/Common/src/main/java/tk/glucodata/headless/HeadlessHistoryExample.java
@@ -1,0 +1,156 @@
+/*      This file is part of Juggluco, an Android app to receive and display         */
+/*      glucose values from Freestyle Libre 2 and 3 sensors.                         */
+/*                                                                                   */
+/*      Copyright (C) 2021 Jaap Korthals Altes <jaapkorthalsaltes@gmail.com>         */
+/*                                                                                   */
+/*      Juggluco is free software: you can redistribute it and/or modify             */
+/*      it under the terms of the GNU General Public License as published            */
+/*      by the GNU General Public License Foundation, either version 3 of the License, or         */
+/*      (at your option) any later version.                                          */
+/*                                                                                   */
+/*      Juggluco is distributed in the hope that it will be useful, but              */
+/*      WITHOUT ANY WARRANTY; without even the implied warranty of                   */
+/*      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                         */
+/*      See the GNU General Public License for more details.                         */
+/*                                                                                   */
+/*      You should have received a copy of the GNU General Public License            */
+/*      along with Juggluco. If not, see <https://www.gnu.org/licenses/>.            */
+
+package tk.glucodata.headless;
+
+import android.util.Log;
+
+/**
+ * Example class demonstrating how to use HeadlessHistory with onGlucose method
+ * This shows the proper way to implement glucose history using the watchdrip structure
+ */
+public class HeadlessHistoryExample {
+    private static final String TAG = "HeadlessHistoryExample";
+    
+    /**
+     * Example implementation of GlucoseListener for history data
+     */
+    public static class ExampleGlucoseListener implements GlucoseListener {
+        @Override
+        public void onGlucose(String serial,
+                             int mgdl,
+                             float value,
+                             float rate,
+                             int alarm,
+                             long timeMillis,
+                             long sensorStartMillis,
+                             int sensorGen) {
+            
+            // Process each glucose reading
+            Log.d(TAG, String.format("Glucose: Serial=%s, mg/dL=%d, value=%.1f, rate=%.2f, alarm=%d, time=%d, sensorStart=%d, gen=%d",
+                    serial, mgdl, value, rate, alarm, timeMillis, sensorStartMillis, sensorGen));
+            
+            // You can add your custom logic here:
+            // - Store in database
+            // - Send to cloud service
+            // - Update UI
+            // - Calculate statistics
+            // - Trigger alarms
+            
+            // Example: Check for high/low glucose
+            if (mgdl > 180) {
+                Log.w(TAG, "High glucose detected: " + mgdl + " mg/dL");
+            } else if (mgdl < 70) {
+                Log.w(TAG, "Low glucose detected: " + mgdl + " mg/dL");
+            }
+            
+            // Example: Check rate of change
+            if (Math.abs(rate) > 2.0) {
+                Log.w(TAG, "Rapid glucose change detected: " + rate + " mg/dL/min");
+            }
+        }
+    }
+    
+    /**
+     * Example of how to set up and use HeadlessHistory
+     */
+    public static void setupHistoryExample(HeadlessJugglucoManager manager) {
+        // Create a glucose listener for history data
+        ExampleGlucoseListener glucoseListener = new ExampleGlucoseListener();
+        
+        // Set the glucose listener for history
+        manager.setGlucoseHistoryListener(glucoseListener);
+        
+        // Now you can get glucose history using onGlucose method
+        
+        // Get all available history for a sensor
+        manager.getGlucoseHistoryOnGlucose("sensor123");
+        
+        // Get history within a time range (last 24 hours)
+        long endTime = System.currentTimeMillis();
+        long startTime = endTime - (24 * 60 * 60 * 1000L); // 24 hours ago
+        manager.getGlucoseHistoryOnGlucose("sensor123", startTime, endTime);
+        
+        // Get history from watchdrip storage (if available)
+        manager.getGlucoseHistoryFromWatchdrip("sensor123");
+        
+        // Get watchdrip history within a time range
+        manager.getGlucoseHistoryOnGlucoseFromWatchdrip("sensor123", startTime, endTime);
+    }
+    
+    /**
+     * Example of how to use HeadlessHistory directly
+     */
+    public static void useHeadlessHistoryDirectly() {
+        // Create a glucose listener
+        ExampleGlucoseListener glucoseListener = new ExampleGlucoseListener();
+        
+        // Create HeadlessHistory with glucose listener
+        HeadlessHistory history = new HeadlessHistory(glucoseListener);
+        
+        // Get history from native data
+        history.emitFromNativeLast("sensor123");
+        
+        // Get history from native data within time range
+        long endTime = System.currentTimeMillis();
+        long startTime = endTime - (2 * 60 * 60 * 1000L); // 2 hours ago
+        history.emitFromNativeRange("sensor123", startTime, endTime);
+        
+        // Get history from watchdrip storage
+        history.emitFromWatchdripHistory("sensor123");
+        
+        // Get watchdrip history within time range
+        history.emitFromWatchdripHistory("sensor123", startTime, endTime);
+    }
+    
+    /**
+     * Example of how to handle both history and glucose listeners
+     */
+    public static void useBothListeners(HeadlessJugglucoManager manager) {
+        // Create both listeners
+        ExampleGlucoseListener glucoseListener = new ExampleGlucoseListener();
+        ExampleHistoryListener historyListener = new ExampleHistoryListener();
+        
+        // Set both listeners
+        manager.setHistoryAndGlucoseListeners(historyListener, glucoseListener);
+        
+        // Now you can use both methods:
+        // Legacy method (HistoryListener)
+        manager.getGlucoseHistory("sensor123");
+        
+        // New method (GlucoseListener with onGlucose)
+        manager.getGlucoseHistoryOnGlucose("sensor123");
+    }
+    
+    /**
+     * Example implementation of HistoryListener for backward compatibility
+     */
+    public static class ExampleHistoryListener implements HistoryListener {
+        @Override
+        public void onHistory(String serial, long[][] pairs) {
+            Log.d(TAG, "History received for " + serial + " with " + pairs.length + " readings");
+            
+            for (int i = 0; i < pairs.length; i++) {
+                long timeMillis = pairs[i][0];
+                long mgdl = pairs[i][1];
+                
+                Log.d(TAG, String.format("History entry %d: time=%d, mg/dL=%d", i, timeMillis, mgdl));
+            }
+        }
+    }
+}

--- a/Common/src/main/java/tk/glucodata/headless/HeadlessJugglucoManager.java
+++ b/Common/src/main/java/tk/glucodata/headless/HeadlessJugglucoManager.java
@@ -82,6 +82,27 @@ public class HeadlessJugglucoManager {
     }
     
     /**
+     * Set glucose listener for glucose history data using onGlucose method
+     * @param listener Glucose listener implementation
+     */
+    public void setGlucoseHistoryListener(GlucoseListener listener) {
+        if (listener != null) {
+            historyManager = new HeadlessHistory(listener);
+        }
+    }
+    
+    /**
+     * Set both history and glucose listeners
+     * @param historyListener History listener implementation
+     * @param glucoseListener Glucose listener implementation
+     */
+    public void setHistoryAndGlucoseListeners(HistoryListener historyListener, GlucoseListener glucoseListener) {
+        if (historyListener != null || glucoseListener != null) {
+            historyManager = new HeadlessHistory(historyListener, glucoseListener);
+        }
+    }
+    
+    /**
      * Set stats listener for glucose statistics
      * @param listener Stats listener implementation
      */
@@ -140,22 +161,60 @@ public class HeadlessJugglucoManager {
     }
     
     /**
-     * Get current glucose history for a sensor
+     * Get current glucose history for a sensor using legacy HistoryListener
      * @param serial Sensor serial number
      */
     public void getGlucoseHistory(String serial) {
         if (historyManager != null) {
-            historyManager.emitFromNativeLast(serial);
+            historyManager.emitFromNativeLastLegacy(serial);
         }
     }
+    
     /**
-     * Get glucose history for a sensor within an optional time range
+     * Get glucose history for a sensor within an optional time range using legacy HistoryListener
      * If startMillis/endMillis are null, they are ignored
      */
     public void getGlucoseHistory(String serial, Long startMillis, Long endMillis) {
         if (historyManager != null) {
+            historyManager.emitFromNativeRangeLegacy(serial, startMillis, endMillis);
+        }
+    }
+    
+    /**
+     * Get glucose history for a sensor using onGlucose method
+     * @param serial Sensor serial number
+     */
+    public void getGlucoseHistoryOnGlucose(String serial) {
+        if (historyManager != null) {
+            historyManager.emitFromNativeLast(serial);
+        }
+    }
+    
+    /**
+     * Get glucose history for a sensor within an optional time range using onGlucose method
+     */
+    public void getGlucoseHistoryOnGlucose(String serial, Long startMillis, Long endMillis) {
+        if (historyManager != null) {
             historyManager.emitFromNativeRange(serial, startMillis, endMillis);
         }
+    }
+    
+    /**
+     * Get glucose history from watchdrip storage using onGlucose method
+     * @param serial Sensor serial number
+     */
+    public void getGlucoseHistoryFromWatchdrip(String serial) {
+        if (historyManager != null) {
+            historyManager.emitFromWatchdripHistory(serial);
+        }
+    }
+    
+    /**
+     * Get glucose history from watchdrip storage within a time range using onGlucose method
+     */
+    public void getGlucoseHistoryOnGlucoseFromWatchdrip(String serial, Long startMillis, Long endMillis) {
+        if (historyManager != null) {
+            historyManager.emitFromWatchdripHistory(serial, startMillis, endMillis);
     }
     
     /**

--- a/Common/src/mobile/java/tk/glucodata/watchdrip.java
+++ b/Common/src/mobile/java/tk/glucodata/watchdrip.java
@@ -35,11 +35,67 @@ import androidx.core.content.ContextCompat;
 
 import com.eveningoutpost.dexdrip.services.broadcastservice.models.Settings;
 
-public class watchdrip extends BroadcastReceiver {
-private static String  LOG_ID="watchdrip";
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 
- static   String  tostring(Bundle bundle) {
-        if(bundle==null)
+import tk.glucodata.headless.GlucoseListener;
+
+public class watchdrip extends BroadcastReceiver {
+    private static String LOG_ID = "watchdrip";
+    
+    // History management
+    private static final int MAX_HISTORY_SIZE = 1000; // Maximum number of glucose readings to keep in memory
+    private static final ConcurrentHashMap<String, List<GlucoseReading>> glucoseHistory = new ConcurrentHashMap<>();
+    private static final ScheduledExecutorService historyCleanupExecutor = Executors.newSingleThreadScheduledExecutor();
+    
+    // Glucose reading data structure matching onGlucose parameters
+    public static class GlucoseReading {
+        public final String serial;
+        public final int mgdl;
+        public final float value;
+        public final float rate;
+        public final int alarm;
+        public final long timeMillis;
+        public final long sensorStartMillis;
+        public final int sensorGen;
+        
+        public GlucoseReading(String serial, int mgdl, float value, float rate, int alarm, 
+                           long timeMillis, long sensorStartMillis, int sensorGen) {
+            this.serial = serial;
+            this.mgdl = mgdl;
+            this.value = value;
+            this.rate = rate;
+            this.alarm = alarm;
+            this.timeMillis = timeMillis;
+            this.sensorStartMillis = sensorStartMillis;
+            this.sensorGen = sensorGen;
+        }
+        
+        @Override
+        public String toString() {
+            return String.format("GlucoseReading{serial='%s', mgdl=%d, value=%.1f, rate=%.2f, alarm=%d, time=%d, sensorStart=%d, gen=%d}",
+                    serial, mgdl, value, rate, alarm, timeMillis, sensorStartMillis, sensorGen);
+        }
+    }
+    
+    // Initialize history cleanup scheduler
+    static {
+        // Clean up old history entries every hour
+        historyCleanupExecutor.scheduleAtFixedRate(() -> {
+            try {
+                cleanupOldHistory();
+            } catch (Exception e) {
+                if(doLog) Log.e(LOG_ID, "History cleanup error: " + e.getMessage());
+            }
+        }, 1, 1, TimeUnit.HOURS);
+    }
+
+    static String tostring(Bundle bundle) {
+        if(bundle == null)
             return "";
         var builder = new StringBuilder();
         builder.append("bundle content\n");
@@ -48,71 +104,226 @@ private static String  LOG_ID="watchdrip";
             builder.append("[" + key + "]<->[" + bundle.get(key) + "]\n");
         }
         return builder.toString();
-    } 
-        @Override
-        public void onReceive(Context context, Intent intent) {
-           	{if(doLog) {Log.i(LOG_ID,"onReceive ");};};
-		var extras=intent.getExtras();
-		if(doLog) Natives.log(tostring(extras));
-		var function=extras.getString("FUNCTION","");
-		if("update_bg_force".equals(function)) {
-			String key=extras.getString("PACKAGE",null);
-			if(key==null) {
-				Log.e(LOG_ID,"no package");
-				return;
-				}
-//			WearInt.settings  = intent.getParcelableExtra("SETTINGS");
-			Settings settings= extras.getParcelable("SETTINGS");
-			if(settings==null) {
-					Log.e(LOG_ID,"settings==null");
-					return;
-				}
-			WearInt.mapsettings.put(key,settings);
-			var gl=Natives.getlastGlucose();
-			if(gl==null)
-					return;
-			long res=gl[1];
-			int glumgdl = (int) (res & 0xFFFFFFFFL);
-			if (glumgdl != 0) {
-				int alarm = (int) ((res >> 48) & 0xFFL);
-				short ratein = (short) ((res >> 32) & 0xFFFFL);
-				float rate = ratein / 1000.0f;
-				var newintent=WearInt.mksendglucoseintent(settings,glumgdl,rate,alarm,  gl[0]*1000L);
-				newintent.putExtra( "FUNCTION","update_bg_force");
-				newintent.setPackage(key);
-				Applic.app.sendBroadcast(newintent);
-				}
-			}
-
-        	}
-static private watchdrip receiver=null;
-@SuppressLint("UnspecifiedRegisterReceiverFlag")
-static void register() {
-	if(receiver==null)
-		receiver=new watchdrip();
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-        Applic.app.registerReceiver(receiver, new IntentFilter("com.eveningoutpost.dexdrip.watch.wearintegration.BROADCAST_SERVICE_RECEIVER"),RECEIVER_EXPORTED);
     }
-	else
-        Applic.app.registerReceiver(receiver, new IntentFilter("com.eveningoutpost.dexdrip.watch.wearintegration.BROADCAST_SERVICE_RECEIVER"));
-}
-static void unregister() {
-	if(receiver!=null) {
-        try {
-            Applic.app.unregisterReceiver(receiver);
-            } 
-       catch(Throwable th) {
-          Log.stack(LOG_ID,"unregister",th);
+    
+    /**
+     * Add glucose reading to history
+     */
+    private static void addToHistory(String serial, int mgdl, float value, float rate, 
+                                   int alarm, long timeMillis, long sensorStartMillis, int sensorGen) {
+        if (serial == null || serial.isEmpty()) {
+            if(doLog) Log.w(LOG_ID, "Cannot add to history: serial is null or empty");
+            return;
+        }
+        
+        GlucoseReading reading = new GlucoseReading(serial, mgdl, value, rate, alarm, 
+                                                  timeMillis, sensorStartMillis, sensorGen);
+        
+        glucoseHistory.computeIfAbsent(serial, k -> new ArrayList<>()).add(reading);
+        
+        // Maintain history size limit
+        List<GlucoseReading> history = glucoseHistory.get(serial);
+        if (history.size() > MAX_HISTORY_SIZE) {
+            history.remove(0); // Remove oldest entry
+        }
+        
+        if(doLog) Log.d(LOG_ID, "Added to history: " + reading);
+    }
+    
+    /**
+     * Get glucose history for a specific sensor
+     */
+    public static List<GlucoseReading> getGlucoseHistory(String serial) {
+        if (serial == null || serial.isEmpty()) {
+            return new ArrayList<>();
+        }
+        return new ArrayList<>(glucoseHistory.getOrDefault(serial, new ArrayList<>()));
+    }
+    
+    /**
+     * Get glucose history for a specific sensor within a time range
+     */
+    public static List<GlucoseReading> getGlucoseHistory(String serial, long startMillis, long endMillis) {
+        if (serial == null || serial.isEmpty()) {
+            return new ArrayList<>();
+        }
+        
+        List<GlucoseReading> allHistory = glucoseHistory.getOrDefault(serial, new ArrayList<>());
+        List<GlucoseReading> filteredHistory = new ArrayList<>();
+        
+        for (GlucoseReading reading : allHistory) {
+            if (reading.timeMillis >= startMillis && reading.timeMillis <= endMillis) {
+                filteredHistory.add(reading);
             }
         }
-	}
+        
+        return filteredHistory;
+    }
+    
+    /**
+     * Get latest glucose reading for a sensor
+     */
+    public static GlucoseReading getLatestGlucose(String serial) {
+        if (serial == null || serial.isEmpty()) {
+            return null;
+        }
+        
+        List<GlucoseReading> history = glucoseHistory.get(serial);
+        if (history == null || history.isEmpty()) {
+            return null;
+        }
+        
+        return history.get(history.size() - 1);
+    }
+    
+    /**
+     * Clean up old history entries (older than 24 hours)
+     */
+    private static void cleanupOldHistory() {
+        long cutoffTime = System.currentTimeMillis() - (24 * 60 * 60 * 1000L); // 24 hours ago
+        
+        for (String serial : glucoseHistory.keySet()) {
+            List<GlucoseReading> history = glucoseHistory.get(serial);
+            if (history != null) {
+                history.removeIf(reading -> reading.timeMillis < cutoffTime);
+                
+                // Remove empty history entries
+                if (history.isEmpty()) {
+                    glucoseHistory.remove(serial);
+                }
+            }
+        }
+        
+        if(doLog) Log.d(LOG_ID, "History cleanup completed. Current entries: " + glucoseHistory.size());
+    }
+    
+    /**
+     * Process glucose data and add to history
+     */
+    private static void processGlucoseData(String serial, long[] gl) {
+        if (gl == null || gl.length < 2) {
+            if(doLog) Log.w(LOG_ID, "Invalid glucose data received");
+            return;
+        }
+        
+        long res = gl[1];
+        int glumgdl = (int) (res & 0xFFFFFFFFL);
+        
+        if (glumgdl != 0) {
+            int alarm = (int) ((res >> 48) & 0xFFL);
+            short ratein = (short) ((res >> 32) & 0xFFFFL);
+            float rate = ratein / 1000.0f;
+            long timeMillis = gl[0] * 1000L; // Convert seconds to milliseconds
+            
+            // Convert to current units
+            float value = Applic.unit == 1 ? glumgdl / Applic.mgdLmult : glumgdl;
+            
+            // Get sensor information (default values if not available)
+            long sensorStartMillis = System.currentTimeMillis() - (24 * 60 * 60 * 1000L); // Default to 24 hours ago
+            int sensorGen = 1; // Default sensor generation
+            
+            // Add to history
+            addToHistory(serial, glumgdl, value, rate, alarm, timeMillis, sensorStartMillis, sensorGen);
+            
+            if(doLog) Log.d(LOG_ID, "Processed glucose data: mgdl=" + glumgdl + ", rate=" + rate + ", alarm=" + alarm);
+        }
+    }
+    
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        {if(doLog) {Log.i(LOG_ID,"onReceive ");};};
+        var extras = intent.getExtras();
+        if(doLog) Natives.log(tostring(extras));
+        var function = extras.getString("FUNCTION","");
+        
+        if("update_bg_force".equals(function)) {
+            String key = extras.getString("PACKAGE",null);
+            if(key == null) {
+                Log.e(LOG_ID,"no package");
+                return;
+            }
+            
+            Settings settings = extras.getParcelable("SETTINGS");
+            if(settings == null) {
+                Log.e(LOG_ID,"settings==null");
+                return;
+            }
+            
+            WearInt.mapsettings.put(key,settings);
+            
+            // Get glucose data
+            var gl = Natives.getlastGlucose();
+            if(gl == null) return;
+            
+            // Process and add to history
+            processGlucoseData(key, gl);
+            
+            // Extract data for wearable intent
+            long res = gl[1];
+            int glumgdl = (int) (res & 0xFFFFFFFFL);
+            
+            if (glumgdl != 0) {
+                int alarm = (int) ((res >> 48) & 0xFFL);
+                short ratein = (short) ((res >> 32) & 0xFFFFL);
+                float rate = ratein / 1000.0f;
+                
+                var newintent = WearInt.mksendglucoseintent(settings, glumgdl, rate, alarm, gl[0] * 1000L);
+                newintent.putExtra("FUNCTION","update_bg_force");
+                newintent.setPackage(key);
+                Applic.app.sendBroadcast(newintent);
+            }
+        }
+    }
+    
+    static private watchdrip receiver = null;
+    
+    @SuppressLint("UnspecifiedRegisterReceiverFlag")
+    static void register() {
+        if(receiver == null)
+            receiver = new watchdrip();
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            Applic.app.registerReceiver(receiver, new IntentFilter("com.eveningoutpost.dexdrip.watch.wearintegration.BROADCAST_SERVICE_RECEIVER"),RECEIVER_EXPORTED);
+        }
+        else
+            Applic.app.registerReceiver(receiver, new IntentFilter("com.eveningoutpost.dexdrip.watch.wearintegration.BROADCAST_SERVICE_RECEIVER"));
+    }
+    
+    static void unregister() {
+        if(receiver != null) {
+            try {
+                Applic.app.unregisterReceiver(receiver);
+            } 
+            catch(Throwable th) {
+                Log.stack(LOG_ID,"unregister",th);
+            }
+        }
+    }
 
-public static void set(boolean val) {
-	SuperGattCallback.doWearInt=val;
-	if(val) {
-		register();
-		}
-	else
-		unregister();
-	}
+    public static void set(boolean val) {
+        SuperGattCallback.doWearInt = val;
+        if(val) {
+            register();
+        }
+        else {
+            unregister();
+        }
+    }
+    
+    /**
+     * Shutdown history management
+     */
+    public static void shutdown() {
+        try {
+            historyCleanupExecutor.shutdown();
+            if (!historyCleanupExecutor.awaitTermination(5, TimeUnit.SECONDS)) {
+                historyCleanupExecutor.shutdownNow();
+            }
+        } catch (InterruptedException e) {
+            historyCleanupExecutor.shutdownNow();
+            Thread.currentThread().interrupt();
+        }
+        
+        glucoseHistory.clear();
+        if(doLog) Log.d(LOG_ID, "Watchdrip history management shutdown completed");
+    }
 }


### PR DESCRIPTION
Refactor `HeadlessHistory` to emit glucose history via `onGlucose` method, aligning with `watchdrip`'s data structure and introducing an in-memory history system.

This standardizes glucose history processing to use the `onGlucose` interface, providing a consistent and robust history management system across `HeadlessHistory` and `watchdrip` components, including automatic cleanup and flexible retrieval.

---
<a href="https://cursor.com/background-agent?bcId=bc-9a608084-f677-4eee-b383-0d4b923b6913">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9a608084-f677-4eee-b383-0d4b923b6913">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

