### PR TITLE
Process watchdrip glucose data and fix history

### DIFF
--- a/Common/src/main/java/tk/glucodata/headless/HeadlessHistory.java
+++ b/Common/src/main/java/tk/glucodata/headless/HeadlessHistory.java
@@ -2,11 +2,33 @@ package tk.glucodata.headless;
 
 import tk.glucodata.Natives;
 
-public final class HeadlessHistory {
+public final class HeadlessHistory implements GlucoseListener {
     private final HistoryListener listener;
 
     public HeadlessHistory(HistoryListener listener) {
         this.listener = listener;
+    }
+
+    // Implementation of GlucoseListener interface for real-time glucose updates
+    @Override
+    public void onGlucose(String serial,
+                         int mgdl,
+                         float value,
+                         float rate,
+                         int alarm,
+                         long timeMillis,
+                         long sensorStartMillis,
+                         int sensorGen) {
+        // Process real-time glucose data similar to watchdrip implementation
+        if (listener != null) {
+            // Create a single entry history array for the current glucose reading
+            long[][] currentGlucose = new long[1][2];
+            currentGlucose[0][0] = timeMillis;
+            currentGlucose[0][1] = mgdl;
+            
+            // Emit the current glucose reading as history
+            listener.onHistory(serial, currentGlucose);
+        }
     }
 
     // Uses Natives.getlastGlucose() which returns a flat long[] as

--- a/Common/src/main/java/tk/glucodata/headless/HeadlessJugglucoManager.java
+++ b/Common/src/main/java/tk/glucodata/headless/HeadlessJugglucoManager.java
@@ -78,6 +78,8 @@ public class HeadlessJugglucoManager {
     public void setHistoryListener(HistoryListener listener) {
         if (listener != null) {
             historyManager = new HeadlessHistory(listener);
+            // Also set up HeadlessHistory as a glucose listener for real-time updates
+            setGlucoseListener(historyManager);
         }
     }
     


### PR DESCRIPTION
Implement `GlucoseListener` in `HeadlessHistory` to provide real-time glucose updates via the existing `HistoryListener` interface.

The `HeadlessHistory` class now receives real-time glucose data, converts it into a history format, and delivers it through the `onHistory` method. This unifies real-time and historical data processing, consistent with the `watchdrip` implementation pattern, ensuring that consumers of `HistoryListener` receive both types of data through a single interface.

---
<a href="https://cursor.com/background-agent?bcId=bc-e0795388-e7de-46ab-bba4-e5a00d00ab41">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e0795388-e7de-46ab-bba4-e5a00d00ab41">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

